### PR TITLE
Minor Updates 

### DIFF
--- a/files_opds/lib/bookshelf.php
+++ b/files_opds/lib/bookshelf.php
@@ -71,7 +71,6 @@ class Bookshelf
 		if($bookshelf = json_decode(Config::get('bookshelf', ''), true)) {
 			arsort($bookshelf);
 			foreach($bookshelf as $id => $time) {
-			/**while (list($id, $time) = each($bookshelf)) { */
 				try {
 					array_push($files, \OC\Files\Filesystem::getFileInfo(\OC\Files\Filesystem::normalizePath(\OC\Files\Filesystem::getPath($id))));
 				} catch(\OCP\Files\NotFoundException $e) {

--- a/files_opds/lib/bookshelf.php
+++ b/files_opds/lib/bookshelf.php
@@ -70,7 +70,8 @@ class Bookshelf
 		$files = array();
 		if($bookshelf = json_decode(Config::get('bookshelf', ''), true)) {
 			arsort($bookshelf);
-			while (list($id, $time) = each($bookshelf)) {
+			foreach($bookshelf as $id => $time) {
+			/**while (list($id, $time) = each($bookshelf)) { */
 				try {
 					array_push($files, \OC\Files\Filesystem::getFileInfo(\OC\Files\Filesystem::normalizePath(\OC\Files\Filesystem::getPath($id))));
 				} catch(\OCP\Files\NotFoundException $e) {

--- a/files_opds/lib/meta.php
+++ b/files_opds/lib/meta.php
@@ -97,7 +97,8 @@ class Meta
 				$meta['subjects'],
 				$meta['cover'],
 				$meta['rescan'],
-				$meta['id']
+ 				date("Y-m-d H:i:s")
+				/** $meta['id'] */
 				);
 
 		} else {
@@ -115,7 +116,8 @@ class Meta
 				mb_strimwidth($meta['description'],0,2044,'...'),
 				$meta['subjects'],
 				$meta['cover'],
-				$meta['rescan']
+				date("Y-m-d H:i:s")				
+				/** $meta['rescan'] */
 				);
 		}
 		$query = \OC_DB::prepare($sql);
@@ -161,7 +163,7 @@ class Meta
 	 */
 	public static function rescan() {
                 $sql = "UPDATE *PREFIX*opds_metadata SET `rescan`=?";
-                $args = array(date("Y-m-d H:i:s"));
+                $args = array(date("Y-m-d H:i:s")); 
                 $query = \OC_DB::prepare($sql);
                 $result = $query->execute($args);
 	}

--- a/files_opds/lib/meta.php
+++ b/files_opds/lib/meta.php
@@ -96,8 +96,8 @@ class Meta
 				mb_strimwidth($meta['description'],0,2044,'...'),
 				$meta['subjects'],
 				$meta['cover'],
-				$meta['rescan'],
- 				date("Y-m-d H:i:s")
+ 				date("Y-m-d H:i:s"),
+				$meta['id']
 				);
 
 		} else {

--- a/files_opds/lib/meta.php
+++ b/files_opds/lib/meta.php
@@ -98,7 +98,6 @@ class Meta
 				$meta['cover'],
 				$meta['rescan'],
  				date("Y-m-d H:i:s")
-				/** $meta['id'] */
 				);
 
 		} else {
@@ -116,8 +115,7 @@ class Meta
 				mb_strimwidth($meta['description'],0,2044,'...'),
 				$meta['subjects'],
 				$meta['cover'],
-				date("Y-m-d H:i:s")				
-				/** $meta['rescan'] */
+				date("Y-m-d H:i:s")
 				);
 		}
 		$query = \OC_DB::prepare($sql);
@@ -163,7 +161,7 @@ class Meta
 	 */
 	public static function rescan() {
                 $sql = "UPDATE *PREFIX*opds_metadata SET `rescan`=?";
-                $args = array(date("Y-m-d H:i:s")); 
+                $args = array(date("Y-m-d H:i:s"));
                 $query = \OC_DB::prepare($sql);
                 $result = $query->execute($args);
 	}


### PR DESCRIPTION
**Each function in Bookshelfs.php needed to resolve error in log:**
The each() function is deprecated. This message will be suppressed on further calls at /var/www/nextcloud/apps/files_opds/lib/bookshelf.php#73

**Rescan meta fix in meta.php needed to resolve error in log:**
Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'UPDATE oc_opds_metadata SET `updated`=?, `date`=?, `author`=?, `title`=?, `language`=?, `publisher`=?, `isbn`=?, `copyright`=?, `description`=?, `subjects`=?, `cover`=?, `rescan`=? WHERE id=?' with params ["2019-03-25 23:27:01", "", "", "Douglas, Adams - The Ultimate Hitchhiker's Guide to the Galaxy (2010, Random House Publishing Group, 978-0-307-49846-5)", "", "", "9780307498465", "", "", "", null, "2019-04-01T23:27:02+00:00", 198359]: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2019-04-01T23:27:02+00:00' for column `NextCloud`.`oc_opds_metadata`.`rescan` at row 1

Have not fixed it in a pretty way but it did work, I'm not a coder that has in-depth knowledge of php or Nextcloud innerworkings so not really sure why the date someware got corrupted so it was not able to enter in mysql/mariadb 


